### PR TITLE
Rust target for linux arm64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,8 @@ jobs:
             target_os: linux
           - arch: aarch64
             target_os: linux
+          - arch: arm64
+            target_os: linux
           - arch: armv7
             target_os: linux
           - arch: armv5

--- a/rust_build_utils/rust_utils.py
+++ b/rust_build_utils/rust_utils.py
@@ -19,12 +19,16 @@ RUST_NIGHTLY_VERSION = "2023-09-10"
 
 @dataclass
 class CargoConfig:
+    """Arch 'arm64' (eg. the macos arch on arm) will be replaced with 'aarch64'."""
+
     target_os: str
     arch: str
     debug: bool
     rust_target: str = ""
 
     def __post_init__(self):
+        if self.arch == "arm64":
+            self.arch = "aarch64"
         self.rust_target = GLOBAL_CONFIG[self.target_os]["archs"][self.arch][
             "rust_target"
         ]


### PR DESCRIPTION
This will allow to run (build) nat-lab on macos host directly without needing to run nat-lab inside of the linux vm