### PR TITLE
Add support for custom gradle files in aar generation and additional gradle 7.6 based docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ on:
         - build-linux-rust
         - build-windows-rust
         - package-aar
+        - package-aar-jdk-17
       version:
         type: string
         required: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,3 +134,39 @@ jobs:
           path: |
             rust_sample/dist/*.aar
             rust_sample/dist/android_aar
+  test-android-artifacts-custom-files:
+    permissions:
+      contents: read
+      packages: read
+    runs-on: ubuntu-22.04
+    needs: test-build-docker
+    container:
+      image: 'ghcr.io/nordsecurity/package-aar-jdk-17:rustls-platform-verifier-jdk17-2'
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-android-x86_64
+          path: rust_sample/dist
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-android-i686
+          path: rust_sample/dist
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-android-aarch64
+          path: rust_sample/dist
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-android-armv7
+          path: rust_sample/dist
+      - run: python3 rust_sample/ci/build_sample.py aar rust_sample com.nordsec.rust_sample rust_sample v1.2.3 $(pwd)/rust_sample/dist/android/java $(pwd)/rust_sample/dist/android/release/stripped --settings_gradle_path $(pwd)/rust_sample/templates/__settings.gradle --build_gradle_path $(pwd)/rust_sample/templates/__build.gradle --init_gradle_path $(pwd)/rust_sample/templates/__init.gradle
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: rust-sample-aar-custom
+          path: |
+            rust_sample/dist/*.aar
+            rust_sample/dist/android_aar

--- a/builders/package-aar-jdk-17/Dockerfile
+++ b/builders/package-aar-jdk-17/Dockerfile
@@ -1,0 +1,50 @@
+FROM openjdk:17-jdk-slim-bullseye
+
+ARG REVISION
+
+LABEL org.opencontainers.image.source=https://github.com/NordSecurity/rust_build_utils
+LABEL org.opencontainers.image.description="AAR packaging image"
+LABEL org.opencontainers.image.licenses=GPL-3.0
+LABEL org.opencontainers.image.revision=$REVISION
+
+ENV ANDROID_COMPILE_SDK 29
+ENV ANDROID_BUILD_TOOLS 29.0.2
+ENV ANDROID_SDK_TOOLS 10406996
+
+ENV ANDROID_SDK_ROOT /root/android-sdk-linux/
+
+ENV WORKDIR /root
+WORKDIR ${WORKDIR}
+
+# Install Android SDK
+RUN apt-get update && apt-get install -y wget bash unzip curl python3 git
+ENV ANDROID_SDK_CHECKSUM 8919e8752979db73d8321e9babe2caedcc393750817c1a5f56c128ec442fb540
+RUN wget --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip && \
+    echo "${ANDROID_SDK_CHECKSUM} android-sdk.zip" | sha256sum --check && \
+    mkdir android-sdk-linux && \
+    unzip -d android-sdk-linux android-sdk.zip && \
+    rm android-sdk.zip
+
+RUN echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} "platforms;android-${ANDROID_COMPILE_SDK}" && \
+    echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} "platform-tools" && \
+    echo y | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} "build-tools;${ANDROID_BUILD_TOOLS}" && \
+    yes | android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_ROOT} --licenses
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV ANDROID_HOME=${WORKDIR}/android-sdk-linux
+ENV PATH=${PATH}:${ANDROID_HOME}/platform-tools
+
+# Install gradle
+ENV GRADLE_VERSION 7.6.3
+
+ENV GRADLE_CHECKSUM 6001aba9b2204d26fa25a5800bb9382cf3ee01ccb78fe77317b2872336eb2f80
+RUN wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip && \
+    echo "${GRADLE_CHECKSUM} gradle-${GRADLE_VERSION}-all.zip" | sha256sum --check && \
+    unzip gradle-${GRADLE_VERSION}-all.zip && \
+    rm gradle-${GRADLE_VERSION}-all.zip
+ENV PATH=${PATH}:${WORKDIR}/gradle-${GRADLE_VERSION}/bin
+
+ENTRYPOINT /bin/bash
+
+ENV WORKDIR ""

--- a/rust_build_utils/rust_utils.py
+++ b/rust_build_utils/rust_utils.py
@@ -224,6 +224,24 @@ def create_cli_parser() -> Any:
         type=str,
         help="Path to dir containing all directories for each arch binary",
     )
+    aar_parser.add_argument(
+        "--settings_gradle_path",
+        type=str,
+        help="Path to settings.gradle to be used instead of the default one",
+        required=False,
+    )
+    aar_parser.add_argument(
+        "--build_gradle_path",
+        type=str,
+        help="Path to build.gradle template to be used instead of the default one",
+        required=False,
+    )
+    aar_parser.add_argument(
+        "--init_gradle_path",
+        type=str,
+        help="Path to init.gradle template to be used instead of the default one",
+        required=False,
+    )
 
     ios_sim_parser = subparsers.add_parser(
         "build-ios-simulator-stubs",

--- a/rust_sample/templates/__build.gradle
+++ b/rust_sample/templates/__build.gradle
@@ -1,0 +1,104 @@
+apply plugin: 'com.android.library'
+apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'maven-publish'
+apply plugin: 'kotlin-android'
+
+buildscript {
+    repositories {
+        jcenter()
+        google()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.18.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
+    }
+}
+
+repositories {
+    google()
+    jcenter()
+    maven { url "https://jitpack.io" }
+    maven { url 'https://maven.google.com' }
+}
+
+def packageName = '$PACKAGE_NAME'
+def packageVersionName = '$VERSION'
+def packageVersionCode = 1
+def repoUrl = System.getenv('ARTIFACTORY_URL')
+def repoUsername = System.getenv('ARTIFACTORY_USERNAME')
+def repoPassword = System.getenv('ARTIFACTORY_PASSWORD')
+
+android {
+    compileSdkVersion 29
+    defaultConfig {
+        minSdkVersion 23
+        targetSdkVersion 29
+        versionCode = packageVersionCode
+        versionName = packageVersionName
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+	implementation "net.java.dev.jna:jna:5.7.0@aar"
+}
+
+publishing {
+    publications {
+        aar(MavenPublication) {
+            groupId packageName
+            version = packageVersionName
+            artifactId '$ARTIFACT_ID'
+            artifact("build/outputs/aar/$${project.getName()}-release.aar")
+
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+
+                configurations.implementation.allDependencies.each {
+                    def dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', it.group)
+                    dependencyNode.appendNode('artifactId', it.name)
+                    dependencyNode.appendNode('version', it.version)
+                    dependencyNode.appendNode('type', 'aar') // The only dependency we have is 'jna' with aar artifact type.
+                }
+            }
+        }
+    }
+}
+
+artifactory {
+    contextUrl = repoUrl
+
+    publish {
+        repository {
+            repoKey = packageVersionName.endsWith('SNAPSHOT') ? 'libs-snapshot-local' : 'libs-release-local'
+            username = repoUsername
+            password = repoPassword
+        }
+        defaults {
+            publications('aar')
+            publishArtifacts = true
+        }
+    }
+
+    resolve {
+        repository {
+            repoKey = 'libs-release'
+            username = repoUsername
+            password = repoPassword
+            maven = true
+        }
+    }
+}

--- a/rust_sample/templates/__init.gradle
+++ b/rust_sample/templates/__init.gradle
@@ -1,0 +1,1 @@
+// Dummy comment $PATH_TO_DEPENDENT_CRATE

--- a/rust_sample/templates/__settings.gradle
+++ b/rust_sample/templates/__settings.gradle
@@ -1,0 +1,2 @@
+include ':main'
+apply from: "./init.gradle";


### PR DESCRIPTION
This change adds 3 optional flags that can be used to customize `settings.gradle`, `build.gradle` and newly added `init.gradle`. This is because libtelio will need to customize those files to support `rustls-platform-verifier` which requires custom setup on android. Since that custom setup requires also newer gradle, a new docker aar image version is added which bumps gradle to `7.6.3` (which cause other things to be updated, like jdk version, and sdk tools - `ANDROID_COMPILE_SDK` still remains set to 29).

Tested with unmodified libtelio, where it worked correctly.