### PR TITLE
Remove rustflags for apple builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## 2.0.0
+- **Breaking** Remove RUSTFLAGS for apple builds. The removal of RUSTFLAGS allows the consuming projects to configure RUSTFLAGS independently. Consumers must set RUSTFLAGS="-C link-arg=-s -C embed-bitcode" manually after updating to this version or add it to a specific profile on cargo manifests.
+
 ## 1.0.0
 - Add support for Windows aarch64 architecture
 - **Breaking** Windows cross compilation no longer supported. Requires MSVC toolchain to be installed. Please use with dedicated Windows runners

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -90,9 +90,6 @@ GLOBAL_CONFIG: Dict[str, Any] = {
                 },
             },
         },
-        "env": {
-            "RUSTFLAGS": ([" -C link-arg=-s -C embed-bitcode "], "set"),
-        },
         "post_build": ["rust_build_utils.darwin_build_utils.assert_version"],
     },
     "ios": {
@@ -104,9 +101,6 @@ GLOBAL_CONFIG: Dict[str, Any] = {
                     "IPHONEOS_DEPLOYMENT_TARGET": (["7.0"], "set"),
                 },
             },
-        },
-        "env": {
-            "RUSTFLAGS": ([" -C link-arg=-s -C embed-bitcode "], "set"),
         },
         "pre_build": ["rust_build_utils.darwin_build_utils.set_sdk"],
         "post_build": ["rust_build_utils.darwin_build_utils.assert_version"],
@@ -121,9 +115,6 @@ GLOBAL_CONFIG: Dict[str, Any] = {
                 },
             },
         },
-        "env": {
-            "RUSTFLAGS": ([" -C link-arg=-s -C embed-bitcode "], "set"),
-        },
         "pre_build": ["rust_build_utils.darwin_build_utils.set_sdk"],
         "post_build": ["rust_build_utils.darwin_build_utils.assert_version"],
     },
@@ -136,9 +127,6 @@ GLOBAL_CONFIG: Dict[str, Any] = {
                     "TVOS_DEPLOYMENT_TARGET": (["10.0"], "set"),
                 },
             },
-        },
-        "env": {
-            "RUSTFLAGS": ([" -C link-arg=-s -C embed-bitcode "], "set"),
         },
         "pre_build": ["rust_build_utils.darwin_build_utils.set_sdk"],
         "post_build": ["rust_build_utils.darwin_build_utils.assert_version"],


### PR DESCRIPTION
Until now rust flags for apple devices were being set on the GLOBAL_CONFIG dictionary. This disallow the developer to customize them as the flags on the script override the value set on the manifest file.

This commit removes this flags from the GLOBAL_CONFIG and the projects who were relying on it as default will have to set them on their manifest file instead.