### PR TITLE
Update iOS deployment target version

### DIFF
--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -20,7 +20,7 @@ jobs:
         debug: ['--debug', '']
     runs-on: ubuntu-22.04
     container:
-      image: ${{ inputs.target_os == 'linux' && 'ghcr.io/nordsecurity/build-linux-rust1.72.1:v0.0.2' || 'ghcr.io/nordsecurity/build-android-rust1.72.1:v0.0.2' }}
+      image: ${{ inputs.target_os == 'linux' && 'ghcr.io/nordsecurity/build-linux-rust1.77.2:v0.0.1' || 'ghcr.io/nordsecurity/build-android-rust1.77.2:v0.0.1' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -96,9 +96,9 @@ GLOBAL_CONFIG: Dict[str, Any] = {
         "archs": {
             "aarch64": {
                 "rust_target": "aarch64-apple-ios",
-                "deployment_assert": ("LC_VERSION_MIN_IPHONEOS", "version", "7.0"),
+                "deployment_assert": ("LC_VERSION_MIN_IPHONEOS", "version", "10.0"),
                 "env": {
-                    "IPHONEOS_DEPLOYMENT_TARGET": (["7.0"], "set"),
+                    "IPHONEOS_DEPLOYMENT_TARGET": (["10.0"], "set"),
                 },
             },
         },

--- a/rust_sample/ci/build_sample.py
+++ b/rust_sample/ci/build_sample.py
@@ -13,7 +13,7 @@ import rust_build_utils.android_build_utils as abu
 
 
 PROJECT_CONFIG = rutils.Project(
-    rust_version="1.72.1",
+    rust_version="1.77.2",
     root_dir=PROJECT_ROOT,
     working_dir=None,
 )
@@ -73,7 +73,7 @@ SAMPLE_CONFIG = {
         "packages": {
             "rust_sample": {
                 "example_binary": "example_binary",
-                "rust_sample": "librust_sample.a",
+                "rust_sample": "librust_sample.dylib",
             },
         },
     },
@@ -81,7 +81,7 @@ SAMPLE_CONFIG = {
         "packages": {
             "rust_sample": {
                 "example_binary": "example_binary",
-                "rust_sample": "librust_sample.a",
+                "rust_sample": "librust_sample.dylib",
             },
         },
     },
@@ -103,10 +103,10 @@ SAMPLE_CONFIG = {
         "archs": {"aarch64": {"env": {"RUSTFLAGS": (" -C debuginfo=2", "set")}}},
         "packages": {
             "rust_sample": {
-                "rust_sample": "librust_sample.a",
+                "rust_sample": "librust_sample.dylib",
             },
             "rust-sample-lib": {
-                "rust-sample-lib": "librust_sample_lib.a",
+                "rust-sample-lib": "librust_sample_lib.dylib",
             },
             "rust_sample_pack": {
                 "rust_sample_pack": "rust_sample_pack",
@@ -168,7 +168,7 @@ def main() -> None:
             / "ffi/rust_sample.h",
         }
         dbu.create_xcframework(
-            PROJECT_CONFIG, args.debug, "RustSample", headers, "librust_sample.a"
+            PROJECT_CONFIG, args.debug, "RustSample", headers, "librust_sample.dylib"
         )
     elif args.command == "aar":
         abu.generate_aar(PROJECT_CONFIG, args)
@@ -177,14 +177,14 @@ def main() -> None:
             PROJECT_CONFIG,
             args.debug,
             args.header or PROJECT_CONFIG.get_root_dir() / "ffi/rust_sample.h",
-            "librust_sample.a",
+            "librust_sample.dylib",
         )
     elif args.command == "build-tvos-simulator-stubs":
         dbu.build_stub_tvos_simulator_libraries(
             PROJECT_CONFIG,
             args.debug,
             args.header or PROJECT_CONFIG.get_root_dir() / "ffi/rust_sample.h",
-            "librust_sample.a",
+            "librust_sample.dylib",
         )
     else:
         assert False, f"unsupported command '{args.command}'"


### PR DESCRIPTION
With the upgrade to the latest rust version v1.77.2, the deployment versions have also to be updated. There was an issue with the static libraries using different linker versions on the sample project, so dynamic linking is now used.