### PR TITLE
Add python3-pip to package-aar images

### DIFF
--- a/builders/package-aar-jdk-17/Dockerfile
+++ b/builders/package-aar-jdk-17/Dockerfile
@@ -17,7 +17,15 @@ ENV WORKDIR /root
 WORKDIR ${WORKDIR}
 
 # Install Android SDK
-RUN apt-get update && apt-get install -y wget bash unzip curl python3 git
+RUN apt-get update && apt-get install -y \
+        bash \
+        curl \
+        git \
+        python3 \
+        python3-pip \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
 ENV ANDROID_SDK_CHECKSUM 8919e8752979db73d8321e9babe2caedcc393750817c1a5f56c128ec442fb540
 RUN wget --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip && \
     echo "${ANDROID_SDK_CHECKSUM} android-sdk.zip" | sha256sum --check && \

--- a/builders/package-aar/Dockerfile
+++ b/builders/package-aar/Dockerfile
@@ -15,7 +15,12 @@ ENV WORKDIR /root
 WORKDIR ${WORKDIR}
 
 # Install Android SDK
-RUN apt-get install -y wget bash
+RUN apt-get update && apt-get install -y \
+    bash \
+    python3 \
+    python3-pip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
 ENV ANDROID_SKD_CHECKSUM 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
 RUN wget --output-document=android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_TOOLS}.zip && \
     echo "${ANDROID_SKD_CHECKSUM} android-sdk.zip" | sha256sum --check && \


### PR DESCRIPTION
1. Add python3-pip to package-aar images.
2. Add `rm -rf /var/lib/apt/lists/*` after apt-get update to reduce image size