### PR TITLE
LLT-5033 dylib xcframework + uniffi bindings generation

### DIFF
--- a/.github/workflows/test_build_native.yml
+++ b/.github/workflows/test_build_native.yml
@@ -23,9 +23,6 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-#     - name: Setup MSVC
-#       uses: egor-tensin/vs-shell@9a932a62d05192eae18ca370155cf877eecc2202 # v2.1
-#       if: ${{ matrix.target_os == 'windows' }}
       - name: Build rust sample
         run: python3 rust_sample/ci/build_sample.py build ${{ inputs.target_os }} ${{ inputs.arch }} ${{ matrix.debug }}
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,13 @@ jobs:
       arch: ${{ matrix.arch }}
       target_os: ${{ matrix.target_os }}
 
+  test-uniffi-generation:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - run: python3 rust_sample/ci/build_sample.py bindings
+      - run: cat rust_sample/dist/bindings/sample.py
+
   test-darwin-artifacts:
     permissions:
       contents: read
@@ -108,7 +115,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: test-build-docker
     container:
-      image: 'ghcr.io/nordsecurity/package-aar:v0.0.1'
+      image: 'ghcr.io/nordsecurity/package-aar:v0.0.2'
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -144,7 +151,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: test-build-docker
     container:
-      image: 'ghcr.io/nordsecurity/package-aar-jdk-17:rustls-platform-verifier-jdk17-2'
+      image: 'ghcr.io/nordsecurity/package-aar-jdk-17:v0.0.2'
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## 2.2.0
+- build_stub_library function now builds either static lib or dynamic lib based on the extension of the output file (.a or .dylib)
+- added functionality for uniffi bindings generation
+
 ## 2.1.0
 - Update minSdkVersion in build.gradle to 24 to support UniFFI generated Kotlin code
 

--- a/rust_sample/ci/build_sample.py
+++ b/rust_sample/ci/build_sample.py
@@ -158,6 +158,10 @@ def main() -> None:
     args = rutils.parse_cli()
     if args.command == "build":
         exec_build(args)
+    elif args.command == "bindings":
+        rutils.generate_uniffi_bindings(
+            PROJECT_CONFIG, "v0.25.0-8", ["python"], "src/sample.udl"
+        )
     elif args.command == "lipo":
         exec_lipo(args)
     elif args.command == "xcframework":

--- a/rust_sample/src/sample.udl
+++ b/rust_sample/src/sample.udl
@@ -1,0 +1,3 @@
+namespace sample {
+    string get_message(boolean hello);
+};


### PR DESCRIPTION
1. Add functionality to build dylib darwin stub in order to build xcframework with dylibs.
2. Add functionality of generating uniffi bindings via rust_build_utils so that it can be easily done locally on developer's machine. 

Note: aar images were updated in: #11. pip module was installed