### PR TITLE
build: Update nightly channel for tvos builds

### DIFF
--- a/rust_build_utils/rust_utils.py
+++ b/rust_build_utils/rust_utils.py
@@ -15,7 +15,7 @@ PackageList = Dict[str, Dict[str, str]]
 LIPO_TARGET_OSES = ["macos", "ios", "tvos"]
 XCFRAMEWORK_TARGET_OSES = ["macos", "ios", "ios-sim", "tvos", "tvos-sim"]
 
-RUST_NIGHTLY_VERSION = "2023-09-10"
+RUST_NIGHTLY_VERSION = "2024-01-25"
 
 
 @dataclass


### PR DESCRIPTION
With libtelio's `rustc` and `Cargo.lock` update there's the need to also update rust for tvOS builds. This PR updates the nightly channel for these builds to `nightly-2024-01-25-aarch64-apple-darwin` with `rustc 1.77.0-nightly`.