### PR TITLE
Change linux armv7 arch name to armv7hf

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
             target_os: linux
           - arch: arm64
             target_os: linux
-          - arch: armv7
+          - arch: armv7hf
             target_os: linux
           - arch: armv5
             target_os: linux

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -55,7 +55,7 @@ GLOBAL_CONFIG: Dict[str, Any] = {
             "i686": {
                 "rust_target": "i686-unknown-linux-gnu",
             },
-            "armv7": {
+            "armv7hf": {
                 "rust_target": "armv7-unknown-linux-gnueabihf",
             },
             "armv5": {


### PR DESCRIPTION
`armv7` is used both for android and linux builds, however android translates to `armv7-eabi` while linux to `armv7-eabihf`.

This PR fixes this arch name difference to avoid future suprises.