### PR TITLE
Update Gradle version in package-aar-jdk-17 image 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   build-docker-and-push:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main'
     runs-on: ubuntu-22.04
     permissions:
       packages: write

--- a/README.md
+++ b/README.md
@@ -7,16 +7,24 @@ This is Nord Security's internal project. It contains utilities used for buildin
 See CHANGELOG.md for changes
 
 ## Building docker images
+
+### Debug images
+With every push to the repository a new debug image is built and pushed to the GitHub Container Registry.
+Every registry has its debug sibling image starting with `debug-` prefix.
+Every push to the repository triggers a build of the debug image tagged with the commit hash.
+
+### Release images
 It is recommended to use GitHub UI to build release versions of docker images. This way there is
-a guarantee that the image is built from the versioned version of the Dockerfile and does not contain
+a guarantee that the image is built from the versioned Dockerfile and does not contain
 any local changes. Additionally the image is labeled with the revision of the project during CI build
-so it is easy to trace back the source code used to build the image.
+so it is easy to trace back the source Dockerfile used to build the image.
+Please release images only from the `main` branch.
 
 To build a docker image on GitHub UI:
 1. Go to the [Actions](https://github.com/NordSecurity/rust_build_utils/actions) page of the project.
 2. Select the [Build and Push Docker Image](https://github.com/NordSecurity/rust_build_utils/actions/workflows/docker.yml) workflow on the left.
 3. Click the `Run workflow` button.
-4. Select branch, set docker image name and tag and click the `Run workflow` button.
+4. Select `main` branch, set docker image name and tag and click the `Run workflow` button.
 5. For builder images you must also specify Rust version this images is based on before running the workflow. It is used for naming the image.
 
 ## Contributions

--- a/builders/package-aar-jdk-17/Dockerfile
+++ b/builders/package-aar-jdk-17/Dockerfile
@@ -18,6 +18,7 @@ WORKDIR ${WORKDIR}
 
 # Install Android SDK
 RUN apt-get update && apt-get install -y \
+        openjdk-11-jdk \
         bash \
         curl \
         git \
@@ -44,9 +45,9 @@ ENV ANDROID_HOME=${WORKDIR}/android-sdk-linux
 ENV PATH=${PATH}:${ANDROID_HOME}/platform-tools
 
 # Install gradle
-ENV GRADLE_VERSION 7.6.3
+ENV GRADLE_VERSION 8.6
 
-ENV GRADLE_CHECKSUM 6001aba9b2204d26fa25a5800bb9382cf3ee01ccb78fe77317b2872336eb2f80
+ENV GRADLE_CHECKSUM 85719317abd2112f021d4f41f09ec370534ba288432065f4b477b6a3b652910d
 RUN wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip && \
     echo "${GRADLE_CHECKSUM} gradle-${GRADLE_VERSION}-all.zip" | sha256sum --check && \
     unzip gradle-${GRADLE_VERSION}-all.zip && \


### PR DESCRIPTION
1. Update README.md
Add information about debug docker images and do not allow pushing
release images from branches different then main
2. Update Gradle version in package-aar-jdk-17 image to 8.6