### PR TITLE
Build docker containers build-linux-rust and build-linux-rust for linux/arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,11 +44,22 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
     - name: Build and push Docker image
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
       with:
         context: .
         file: builders/${{ inputs.name }}/Dockerfile
+        builder: ${{ steps.buildx.outputs.name }}
+        platforms: |-
+          ${{ (github.event.inputs.name == 'build-linux-rust' || github.event.inputs.name == 'build-windows-rust') && 'linux/amd64,linux/arm64' ||
+              'linux/amd64' }}
         push: true
         tags: ${{ env.REGISTRY }}/nordsecurity/${{ inputs.name }}${{ inputs.rust_version }}:${{ inputs.version }}
         build-args: |
@@ -77,12 +88,23 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
     - name: Build and push Docker image
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
       with:
         context: .
         file: builders/${{ matrix.name }}/Dockerfile
+        builder: ${{ steps.buildx.outputs.name }}
+        platforms: |-
+          ${{ (matrix.name == 'build-linux-rust' || matrix.name == 'build-windows-rust') && 'linux/amd64,linux/arm64' ||
+              'linux/amd64' }}
         push: true
-        tags: ${{ env.REGISTRY }}/nordsecurity/debug-${{ matrix.name }}:${{ github.sha }}
+        tags: ${{ env.REGISTRY }}/nordsecurity/${{ matrix.name }}:debug-${{ github.sha }}
         build-args: |
           REVISION=${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## 3.3.0
+- build-linux-rust and build-linux-rust are now built also for linux/arm64
+
 ## 3.2.0
 - Add `python-requests` to Docker images
 - Allow uniffi gnerator to run outside docker

--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -12,17 +12,26 @@ COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen
 COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen-go /bin
 COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen-cpp /bin
 
+# Multilib is not present in an arm64 debian but is used by libtelio
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    if apt-cache show gcc-10-multilib > /dev/null 2>&1; then \
+        apt-get install -y gcc-10-multilib; \
+    else \
+        echo "Package gcc-10-multilib does not exist. Skipping installation."; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
+
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
     apt-get install -y \
         # `g++-*` is used by libnudler
-        # `gcc-10-multilib` is used by libtelio
         g++-aarch64-linux-gnu \
         g++-arm-linux-gnueabi \
         g++-arm-linux-gnueabihf \
         g++-i686-linux-gnu \
-        gcc-10-multilib \
         gcc-aarch64-linux-gnu \
         gcc-arm-linux-gnueabi \
         gcc-arm-linux-gnueabihf \


### PR DESCRIPTION
Until now only linux/amd64 images had been built. This meant that other platforms wouldn't work or had to use costly emulation (eg. on arm macos docker runs by default linux/arm64 but can emulate linux/amd64).

With this change build-linux-rust and build-linux-rust are made to work on linux/arm64 using `buildx` + `qemu`.