### PR TITLE
Fix paths for dylibs for Apple platforms

### DIFF
--- a/rust_build_utils/darwin_build_utils.py
+++ b/rust_build_utils/darwin_build_utils.py
@@ -185,17 +185,17 @@ def create_xcframework(
         command = ["xcodebuild", "-create-xcframework"]
 
         for target_os in target_os_list:
-            command.extend(
-                [
-                    "-library",
-                    str(
-                        get_universal_library_distribution_directory(
-                            project, target_os, debug
-                        )
-                        / library_file_name
-                    ),
-                ]
+            lib_path = str(
+                get_universal_library_distribution_directory(project, target_os, debug)
+                / library_file_name
             )
+
+            # fix @rpath to relative one since the absolute is embedded at this point
+            subprocess.run(
+                ["install_name_tool", "-id", f"@rpath/{library_file_name}", lib_path],
+                check=True,
+            )
+            command.extend(["-library", lib_path])
             command.extend(["-headers", str(temp_headers)])
 
         command.extend(["-output", str(framework_path)])


### PR DESCRIPTION
Embedded paths in dylibs are absolute paths of
where they were built. This makes it so that on CI it embeds the full CI path of artefacts which is then traversed and the binary is not found when linking.

To fix that `install_name_tool` must be used.

The effects can be observed by using MacOS tool
called `otool`(part of XCode tools).
```
$ otool lib.dylib
...
Load command 3
    cmd LC_ID_DYLIB
    name /Users/[REDACTED]/target/lib.dylib
...
```