### PR TITLE
Update build-info-extractor-gradle to 4.23.4

### DIFF
--- a/aar_templates/__build.gradle
+++ b/aar_templates/__build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.18.2"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.23.4"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21"
     }
 }

--- a/rust_sample/templates/__build.gradle
+++ b/rust_sample/templates/__build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.0.1'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.23.4"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23"
     }
 }


### PR DESCRIPTION
In main there are 2 workflow job failing:
[test-android-artifacts](https://github.com/NordSecurity/rust_build_utils/actions/runs/11175996442/job/31068461779) and [test-android-artifacts-custom-files](https://github.com/NordSecurity/rust_build_utils/actions/runs/11175996442/job/31068461504)
with error:
> Could not find org.jfrog.buildinfo:build-info-extractor-gradle:4.18.2

It looks like this version is not available anymore in [https://jcenter.bintray.com/org/jfrog/buildinfo/build-info-extractor-gradle](https://jcenter.bintray.com/org/jfrog/buildinfo/build-info-extractor-gradle)

Hence updating references to the nearest version which is 4.23.4
