### PR TITLE
Add qnap deps to linux builder docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ See CHANGELOG.md for changes
 
 ### Debug images
 With every push to the repository a new debug image is built and pushed to the GitHub Container Registry.
-Every registry has its debug sibling image starting with `debug-` prefix.
-Every push to the repository triggers a build of the debug image tagged with the commit hash.
+This debug image is tagged: debug-{commit hash}.
 
 ### Release images
 It is recommended to use GitHub UI to build release versions of docker images. This way there is

--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -12,6 +12,9 @@ COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen
 COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen-go /bin
 COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen-cpp /bin
 
+ENV QDK_TAG=v2.3.14
+ENV SCCACHE_TAG=0.4.2
+
 # Multilib is not present in an arm64 debian but is used by libtelio
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
@@ -21,7 +24,11 @@ RUN set -eux; \
     else \
         echo "Package gcc-10-multilib does not exist. Skipping installation."; \
     fi; \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* \
+        /var/cache/apt/* \
+        /var/log/* \
+        /usr/share/doc/ \
+        /usr/share/man/
 
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
@@ -40,7 +47,11 @@ RUN set -eux; \
         pip \
         python3-requests \
         pkg-config; \
-    rm -rf /var/lib/apt/lists/*;
+    rm -rf /var/lib/apt/lists/* \
+        /var/cache/apt/* \
+        /var/log/* \
+        /usr/share/doc/ \
+        /usr/share/man/
 
 RUN rustup target add \
         x86_64-unknown-linux-gnu \
@@ -55,4 +66,15 @@ RUN rustup component add clippy rustfmt
 RUN cargo search --limit 1
 
 # Install `sccache`
-RUN cargo install sccache --version 0.4.2
+RUN cargo install sccache --locked --version "${SCCACHE_TAG}"
+
+# Install QDK framework for QNAP packages (QPKG)
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    git clone https://github.com/qnap-dev/QDK.git --branch "${QDK_TAG}"; \
+    cd QDK && ./InstallToUbuntu.sh install && cd -; \
+    rm -rf QDK \
+        /var/lib/apt/lists/* \
+        /var/cache/apt/* /var/log/* \
+        /usr/share/doc/ \
+        /usr/share/man/

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -70,6 +70,15 @@ GLOBAL_CONFIG: Dict[str, Any] = {
         },
         "post_build": ["rust_build_utils.linux_build_utils.strip"],
     },
+    "qnap": {
+        "archs": {
+            "x86_64": {
+                "strip_path": "/usr/bin/objcopy",
+                "rust_target": "x86_64-unknown-linux-gnu",
+            },
+        },
+        "post_build": ["rust_build_utils.linux_build_utils.strip"],
+    },
     "windows": {
         "archs": {
             "x86_64": {


### PR DESCRIPTION
As devs we want to support qnap device and for that, it would be useful to have a docker image with the QDK framework already configured so that the final QPKG with the libtelio library can be built and ready to be installed onto the QNAP device.