### PR TITLE
build: Change qnap triple to musl

### DIFF
--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -44,10 +44,12 @@ RUN set -eux; \
         gcc-arm-linux-gnueabihf \
         gcc-i686-linux-gnu \
         libssl-dev \
+        musl-dev \
+        musl-tools \
         pip \
         python3-requests \
         pkg-config; \
-    rm -rf /var/lib/apt/lists/* \
+        rm -rf /var/lib/apt/lists/* \
         /var/cache/apt/* \
         /var/log/* \
         /usr/share/doc/ \
@@ -55,6 +57,7 @@ RUN set -eux; \
 
 RUN rustup target add \
         x86_64-unknown-linux-gnu \
+        x86_64-unknown-linux-musl \
         i686-unknown-linux-gnu \
         armv7-unknown-linux-gnueabihf \
         aarch64-unknown-linux-gnu \

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -74,7 +74,7 @@ GLOBAL_CONFIG: Dict[str, Any] = {
         "archs": {
             "x86_64": {
                 "strip_path": "/usr/bin/objcopy",
-                "rust_target": "x86_64-unknown-linux-gnu",
+                "rust_target": "x86_64-unknown-linux-musl",
             },
         },
         "post_build": ["rust_build_utils.linux_build_utils.strip"],


### PR DESCRIPTION
Change qnap rust target triple from `x86_64-unknown-linux-gnu` to `x86_64-unknown-linux-musl`.