### PR TITLE
NUD-40 Build stubless library for darwin simulators

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,16 +11,28 @@ jobs:
         include:
           - arch: x86_64
             target_os: macos
-            runner: macos-12
+            runner: macos-13
           - arch: aarch64
             target_os: macos
-            runner: macos-12
+            runner: macos-13
           - arch: aarch64
             target_os: ios
-            runner: macos-12
+            runner: macos-13
           - arch: aarch64
             target_os: tvos
-            runner: macos-12
+            runner: macos-13
+          - arch: aarch64
+            target_os: ios-sim
+            runner: macos-13
+          - arch: aarch64
+            target_os: tvos-sim
+            runner: macos-13
+          - arch: x86_64
+            target_os: ios-sim
+            runner: macos-13
+          - arch: x86_64
+            target_os: tvos-sim
+            runner: macos-13
           - arch: x86_64
             target_os: windows
             runner: windows-2022
@@ -79,7 +91,7 @@ jobs:
     strategy:
       matrix:
         debug: ['--debug', '']
-    runs-on: macos-12
+    runs-on: macos-13
     needs: test-build-native
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -98,6 +110,22 @@ jobs:
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: rust-sample-tvos-aarch64${{ matrix.debug }}
+          path: rust_sample/dist
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-ios-sim-aarch64${{ matrix.debug }}
+          path: rust_sample/dist
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-tvos-sim-aarch64${{ matrix.debug }}
+          path: rust_sample/dist
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-ios-sim-x86_64${{ matrix.debug }}
+          path: rust_sample/dist
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: rust-sample-tvos-sim-x86_64${{ matrix.debug }}
           path: rust_sample/dist
       - run: python3 rust_sample/ci/build_sample.py lipo ${{ matrix.debug }}
       - run: python3 rust_sample/ci/build_sample.py build-ios-simulator-stubs ${{ matrix.debug }}

--- a/builders/build-android-rust/Dockerfile
+++ b/builders/build-android-rust/Dockerfile
@@ -53,7 +53,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install `sccache`
-RUN cargo install sccache --version 0.4.2
+RUN cargo install sccache --locked --version 0.4.2
 
 # Skip llt-secrets check when building in builder images
 ENV BYPASS_LLT_SECRETS=1

--- a/builders/build-windows-rust/Dockerfile
+++ b/builders/build-windows-rust/Dockerfile
@@ -33,7 +33,7 @@ RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz; \
     mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH";
 
 # Install `sccache`
-RUN cargo install sccache --version 0.4.2 && rm -rf /usr/local/cargo/registry
+RUN cargo install sccache --locked --version 0.4.2 && rm -rf /usr/local/cargo/registry
 
 # Skip llt-secrets check when building in builder images
 ENV BYPASS_LLT_SECRETS=1

--- a/rust_build_utils/rust_utils.py
+++ b/rust_build_utils/rust_utils.py
@@ -12,7 +12,7 @@ from rust_build_utils.msvc import activate_msvc, deactivate_msvc, is_msvc_active
 
 PackageList = Dict[str, Dict[str, str]]
 
-LIPO_TARGET_OSES = ["macos", "ios", "tvos"]
+LIPO_TARGET_OSES = ["macos", "ios", "ios-sim", "tvos", "tvos-sim"]
 XCFRAMEWORK_TARGET_OSES = ["macos", "ios", "ios-sim", "tvos", "tvos-sim"]
 
 RUST_NIGHTLY_VERSION = "2024-12-16"

--- a/rust_build_utils/rust_utils.py
+++ b/rust_build_utils/rust_utils.py
@@ -15,7 +15,7 @@ PackageList = Dict[str, Dict[str, str]]
 LIPO_TARGET_OSES = ["macos", "ios", "tvos"]
 XCFRAMEWORK_TARGET_OSES = ["macos", "ios", "ios-sim", "tvos", "tvos-sim"]
 
-RUST_NIGHTLY_VERSION = "2024-01-25"
+RUST_NIGHTLY_VERSION = "2024-12-16"
 
 
 @dataclass

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -132,6 +132,30 @@ GLOBAL_CONFIG: Dict[str, Any] = {
         "pre_build": ["rust_build_utils.darwin_build_utils.set_sdk"],
         "post_build": ["rust_build_utils.darwin_build_utils.assert_version"],
     },
+    "ios-sim": {
+        "archs": {
+            "aarch64": {
+                "rust_target": "aarch64-apple-ios-sim",
+                "deployment_assert": ("LC_BUILD_VERSION", "minos", "14.0"),
+                "env": {
+                    "IPHONEOS_DEPLOYMENT_TARGET": (["10.0"], "set"),
+                },
+            },
+            "x86_64": {
+                "rust_target": "x86_64-apple-ios",
+                "deployment_assert": ("LC_VERSION_MIN_IPHONEOS", "version", "10.0"),
+                "env": {
+                    "IPHONEOS_DEPLOYMENT_TARGET": (["10.0"], "set"),
+                },
+            },
+        },
+        "env": {
+            "CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO": (["packed"], "set"),
+            "CARGO_PROFILE_RELEASE_STRIP": (["true"], "set"),
+        },
+        "pre_build": ["rust_build_utils.darwin_build_utils.set_sdk"],
+        "post_build": ["rust_build_utils.darwin_build_utils.assert_version"],
+    },
     "tvos": {
         "archs": {
             "aarch64": {
@@ -151,6 +175,13 @@ GLOBAL_CONFIG: Dict[str, Any] = {
     },
     "tvos-sim": {
         "archs": {
+            "aarch64": {
+                "rust_target": "aarch64-apple-tvos-sim",
+                "deployment_assert": ("LC_BUILD_VERSION", "minos", "14.0"),
+                "env": {
+                    "TVOS_DEPLOYMENT_TARGET": (["10.0"], "set"),
+                },
+            },
             "x86_64": {
                 "rust_target": "x86_64-apple-tvos",
                 "deployment_assert": ("LC_VERSION_MIN_TVOS", "version", "10.0"),

--- a/rust_sample/ci/build_sample.py
+++ b/rust_sample/ci/build_sample.py
@@ -85,6 +85,22 @@ SAMPLE_CONFIG = {
             },
         },
     },
+    "ios-sim": {
+        "packages": {
+            "rust_sample": {
+                "example_binary": "example_binary",
+                "rust_sample": "librust_sample.dylib",
+            },
+        },
+    },
+    "tvos-sim": {
+        "packages": {
+            "rust_sample": {
+                "example_binary": "example_binary",
+                "rust_sample": "librust_sample.dylib",
+            },
+        },
+    },
     "linux": {
         "packages": {
             "rust_sample": {


### PR DESCRIPTION
Adding stubless `ios-sim` and `tvos-sim` build targets to darwin.