### PR TITLE
Fix linter and deprecated actions

### DIFF
--- a/.github/workflows/test_build_docker.yml
+++ b/.github/workflows/test_build_docker.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Build rust sample
         run: python3 rust_sample/ci/build_sample.py build ${{ inputs.target_os }} ${{ inputs.arch }} ${{ matrix.debug }}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: rust-sample-${{ inputs.target_os }}-${{ inputs.arch }}${{ matrix.debug }}
           path: rust_sample/dist

--- a/.github/workflows/test_build_native.yml
+++ b/.github/workflows/test_build_native.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Build rust sample
         run: python3 rust_sample/ci/build_sample.py build ${{ inputs.target_os }} ${{ inputs.arch }} ${{ matrix.debug }}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: rust-sample-${{ inputs.target_os }}-${{ inputs.arch }}${{ matrix.debug }}
           path: rust_sample/dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,35 +95,35 @@ jobs:
     needs: test-build-native
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-macos-x86_64${{ matrix.debug }}
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-macos-aarch64${{ matrix.debug }}
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-ios-aarch64${{ matrix.debug }}
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-tvos-aarch64${{ matrix.debug }}
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-ios-sim-aarch64${{ matrix.debug }}
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-tvos-sim-aarch64${{ matrix.debug }}
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-ios-sim-x86_64${{ matrix.debug }}
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-tvos-sim-x86_64${{ matrix.debug }}
           path: rust_sample/dist
@@ -149,19 +149,19 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-x86_64
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-i686
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-aarch64
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-armv7
           path: rust_sample/dist
@@ -185,19 +185,19 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-x86_64
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-i686
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-aarch64
           path: rust_sample/dist
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: rust-sample-android-armv7
           path: rust_sample/dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,7 @@ jobs:
       - run: python3 rust_sample/ci/build_sample.py build-ios-simulator-stubs ${{ matrix.debug }}
       - run: python3 rust_sample/ci/build_sample.py build-tvos-simulator-stubs ${{ matrix.debug }}
       - run: python3 rust_sample/ci/build_sample.py xcframework ${{ matrix.debug }}
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: rust-sample-xcframework
           path: rust_sample/dist/darwin/*.xcframework
@@ -166,7 +166,7 @@ jobs:
           name: rust-sample-android-armv7
           path: rust_sample/dist
       - run: python3 rust_sample/ci/build_sample.py aar rust_sample com.nordsec.rust_sample rust_sample v1.2.3 $(pwd)/rust_sample/dist/android/java $(pwd)/rust_sample/dist/android/release
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: rust-sample-aar
           path: |
@@ -202,7 +202,7 @@ jobs:
           name: rust-sample-android-armv7
           path: rust_sample/dist
       - run: python3 rust_sample/ci/build_sample.py aar rust_sample com.nordsec.rust_sample rust_sample v1.2.3 $(pwd)/rust_sample/dist/android/java $(pwd)/rust_sample/dist/android/release --settings_gradle_path $(pwd)/rust_sample/templates/__settings.gradle --build_gradle_path $(pwd)/rust_sample/templates/__build.gradle --init_gradle_path $(pwd)/rust_sample/templates/__init.gradle
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: rust-sample-aar-custom
           path: |

--- a/rust_sample/ci/build_sample.py
+++ b/rust_sample/ci/build_sample.py
@@ -186,7 +186,12 @@ def main() -> None:
             / "ffi/rust_sample.h",
         }
         dbu.create_xcframework(
-            PROJECT_CONFIG, args.debug, "RustSample", "librust_sample_framework", headers, "librust_sample.dylib"
+            PROJECT_CONFIG,
+            args.debug,
+            "RustSample",
+            "librust_sample_framework",
+            headers,
+            "librust_sample.dylib",
         )
     elif args.command == "aar":
         abu.generate_aar(PROJECT_CONFIG, args)


### PR DESCRIPTION
This PR also contains the following fixes:
- Black linter has been updated by dependabot and it's now failing.
- actions/upload-artifact v3.x.x was deprecated and v4.x.x should be used.
- actions/download-artifact v3.x.x was deprecated and v4.x.x should be used.

see: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
