### PR TITLE
Allow uniffi cpp geneation

### DIFF
--- a/rust_build_utils/rust_utils.py
+++ b/rust_build_utils/rust_utils.py
@@ -566,7 +566,7 @@ def generate_uniffi_bindings(
             for language in languages:
                 if language in ["kotlin", "swift", "python"]:
                     command = ["uniffi-bindgen", "generate", "--language", language]
-                elif language in ["cs", "go"]:
+                elif language in ["cs", "go", "cpp"]:
                     command = [f"uniffi-bindgen-{language}"]
                 else:
                     raise ValueError(f"Unsupported language: {language}")


### PR DESCRIPTION
uniffi-generators alt ready contained uniffi-bingen-cpp, as we might soon need cpp bindings for most of llt libs, exposing this via python utils.