### PR TITLE
Run post actions lazily

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,8 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
+      with:
+        image: tonistiigi/binfmt:qemu-v7.0.0-28 # See: https://github.com/docker/setup-qemu-action/issues/198#issuecomment-2653791775
 
     - name: Set up Docker Buildx
       id: buildx
@@ -90,6 +92,8 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+      with:
+        image: tonistiigi/binfmt:qemu-v7.0.0-28 # See: https://github.com/docker/setup-qemu-action/issues/198#issuecomment-2653791775
 
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,21 +38,21 @@ jobs:
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
-    - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+    - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3
+      uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+      uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+      uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
       with:
         context: .
         file: builders/${{ inputs.name }}/Dockerfile


### PR DESCRIPTION
Skip running post actions if all artifacts are unchanged.

Additionally, to fix segfaults under docker ([link](https://github.com/NordSecurity/rust_build_utils/actions/runs/13454646480/job/37596923484)) to changes are made:
- various docker related actions are updated to latest versions
- qemu image version is pinned to specific version that fixes the crash (this can be removed in future when https://github.com/docker/setup-qemu-action/issues/198 is fixed)