### PR TITLE
Bump gradle version to 8.10.2

### DIFF
--- a/builders/package-aar-jdk-17/Dockerfile
+++ b/builders/package-aar-jdk-17/Dockerfile
@@ -46,9 +46,9 @@ ENV ANDROID_HOME=${WORKDIR}/android-sdk-linux
 ENV PATH=${PATH}:${ANDROID_HOME}/platform-tools
 
 # Install gradle
-ENV GRADLE_VERSION 8.6
+ENV GRADLE_VERSION 8.10.2
 
-ENV GRADLE_CHECKSUM 85719317abd2112f021d4f41f09ec370534ba288432065f4b477b6a3b652910d
+ENV GRADLE_CHECKSUM 2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6
 RUN wget https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip && \
     echo "${GRADLE_CHECKSUM} gradle-${GRADLE_VERSION}-all.zip" | sha256sum --check && \
     unzip gradle-${GRADLE_VERSION}-all.zip && \


### PR DESCRIPTION
Bumping gradle version, to be able to use `com.android.tools.build:gradle:8.8.0` in gradle scripts, which mitigates [netty](https://nordsec.atlassian.net/browse/VCP-3655) vulnerability.