### PR TITLE
Update XCFramework generation (LLT-5973 + LLT-6051)

### DIFF
--- a/rust_build_utils/darwin_build_utils.py
+++ b/rust_build_utils/darwin_build_utils.py
@@ -147,8 +147,7 @@ def create_fat_binary(
 
     rutils.run_command(command)
 
-
-def _framework_info_plist(framework_name) -> str:
+def _framework_info_plist(framework_name: str, min_os_version: str) -> str:
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -176,7 +175,7 @@ def _framework_info_plist(framework_name) -> str:
 """
 
 
-def _framework_modulemap(framework_name) -> str:
+def _framework_modulemap(framework_name: str) -> str:
     return f"""framework module {framework_name} {{
 	umbrella "."
 	export *

--- a/rust_build_utils/darwin_build_utils.py
+++ b/rust_build_utils/darwin_build_utils.py
@@ -170,7 +170,7 @@ def _framework_info_plist(framework_name) -> str:
   <key>CFBundleShortVersionString</key>
   <string>1.0.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>{min_os_version}</string>
 </dict>
 </plist>
 """
@@ -207,13 +207,64 @@ def _temp_framework_directory(
     with open(framework_modules_dir / "module.modulemap", "w") as modulemap:
         modulemap.write(_framework_modulemap(framework_name))
 
-    with open(framework_dir / "Info.plist", "w") as info_plist:
-        info_plist.write(_framework_info_plist(framework_name))
-
     try:
         yield framework_dir
     finally:
         shutil.rmtree(framework_dir)
+
+
+def _min_os_version_for_arch(filename: str, arch: str) -> str:
+    output = subprocess.check_output(
+        [
+            "vtool",
+            "-arch",
+            arch,
+            "-show-build",
+            filename
+        ]
+    ).decode("utf-8")
+
+    # This is pretty nasty extraction of the vtool output, but it does crash
+    # nicely with unexpected changes in format.
+    # Originally tested against macOS 14.7.4 (23H420)
+
+    lines = output.split("\n")
+    properties = dict()
+    for line in lines[2:-1]:
+        key, value = line.split()
+        properties[key] = value
+
+    platform_version_min = [
+        "LC_VERSION_MIN_MACOSX",
+        "LC_VERSION_MIN_IPHONEOS",
+        "LC_VERSION_MIN_TVOS"
+    ]
+
+    if properties["cmd"] in platform_version_min:
+        return properties["version"]
+    elif properties["cmd"] == "LC_BUILD_VERSION":
+        return properties["minos"]
+    else:
+        raise Exception("Unable to extract minimum OS version")
+
+
+def _min_os_version(filename: str) -> str:
+    archs = subprocess.check_output(["lipo", filename, "-archs"]).split()
+
+    min_os_versions = []
+
+    for arch in archs:
+        arch = arch.decode("utf-8")
+
+        min_os_versions.append(_min_os_version_for_arch(filename, arch))
+
+    # Unclear what the policy should be for fat binaries/simulator builds
+    # with different values for each arch
+    # - max for highest supported version is safe
+    # - min for lowest supported version - do not know if correct or not
+    version_policy = max
+
+    return version_policy(min_os_versions)
 
 
 def create_xcframework(
@@ -262,6 +313,13 @@ def create_xcframework(
             shutil.copyfile(
                 lib_path, framework_path / swift_module_name, follow_symlinks=False
             )
+            with open(framework_path / "Info.plist", "w") as info_plist:
+                info_plist.write(
+                    _framework_info_plist(
+                        framework_name,
+                        _min_os_version(framework_path / swift_module_name)
+                    )
+                )
 
             command.extend(["-framework", str(framework_path)])
 

--- a/rust_build_utils/darwin_build_utils.py
+++ b/rust_build_utils/darwin_build_utils.py
@@ -190,13 +190,17 @@ def _temp_framework_directory(
     framework_dir = Path(project.get_distribution_dir()) / f"{framework_name}.framework"
     if framework_dir.exists():
         shutil.rmtree(framework_dir)
-
     framework_dir.mkdir(parents=True)
 
-    framework_headers_dir = framework_dir / "Headers"
-    framework_modules_dir = framework_dir / "Modules"
+    framework_version_dir = framework_dir / "Versions" / "A"
+    framework_version_dir.mkdir(parents=True)
+
+    framework_headers_dir   = framework_version_dir / "Headers"
     framework_headers_dir.mkdir()
+    framework_modules_dir   = framework_version_dir / "Modules"
     framework_modules_dir.mkdir()
+    framework_resources_dir = framework_version_dir / "Resources"
+    framework_resources_dir.mkdir()
 
     for key, value in headers_directory.items():
         destination = framework_headers_dir / key
@@ -205,6 +209,9 @@ def _temp_framework_directory(
 
     with open(framework_modules_dir / "module.modulemap", "w") as modulemap:
         modulemap.write(_framework_modulemap(framework_name))
+
+    framework_current_symlink = ( framework_dir / "Versions" / "Current" )
+    os.symlink("A", framework_current_symlink, target_is_directory=True)
 
     try:
         yield framework_dir
@@ -306,17 +313,21 @@ def create_xcframework(
                 / f"{swift_module_name}.framework"
             )
 
+            framework_version_path = framework_path / "Versions" / "A"
+
             if framework_path.exists():
                 shutil.rmtree(framework_path)
             shutil.copytree(temp_framework, framework_path, symlinks=True)
             shutil.copyfile(
-                lib_path, framework_path / swift_module_name, follow_symlinks=False
+                lib_path, framework_version_path / swift_module_name, follow_symlinks=False
             )
-            with open(framework_path / "Info.plist", "w") as info_plist:
+            os.symlink(f"Versions/Current/{swift_module_name}", framework_path / swift_module_name)
+
+            with open(framework_version_path / "Resources" / "Info.plist", "w") as info_plist:
                 info_plist.write(
                     _framework_info_plist(
                         framework_name,
-                        _min_os_version(framework_path / swift_module_name)
+                        _min_os_version(framework_version_path / swift_module_name)
                     )
                 )
 


### PR DESCRIPTION
Single PR combining updates to XCFramework generation (please review commits separately)

LLT-5973: Populate XCFramework min OS version from binary info
LLT-6051: Add versioning structure to Frameworks

PR opened while I'm still working through testing with apps. I will update/confirm no issues when I've completed testing.