### PR TITLE
Bump rust version to 1.85.0

### DIFF
--- a/builders/build-android-rust/Dockerfile
+++ b/builders/build-android-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77.2
+FROM rust:1.85.0
 
 ARG REVISION
 
@@ -42,18 +42,12 @@ RUN \
     rustup target add armv7-linux-androideabi && \
     rustup target add aarch64-linux-android
 
-# Download crates.io index - entire index won't have to be downloaded for each job
-RUN cargo search --limit 1
-
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         pip \
         libssl-dev pkg-config \
         python3-requests && \
     rm -rf /var/lib/apt/lists/*
-
-# Install `sccache`
-RUN cargo install sccache --locked --version 0.4.2
 
 # Skip llt-secrets check when building in builder images
 ENV BYPASS_LLT_SECRETS=1

--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77.2-bullseye
+FROM rust:1.85.0-bullseye
 
 ARG REVISION
 
@@ -13,7 +13,6 @@ COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen
 COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.25.0-8 /bin/uniffi-bindgen-cpp /bin
 
 ENV QDK_TAG=v2.3.14
-ENV SCCACHE_TAG=0.4.2
 
 # Multilib is not present in an arm64 debian but is used by libtelio
 RUN set -eux; \
@@ -64,12 +63,6 @@ RUN rustup target add \
         arm-unknown-linux-gnueabi
 
 RUN rustup component add clippy rustfmt
-
-# Download crates.io index - entire index won't have to be downloaded for each job
-RUN cargo search --limit 1
-
-# Install `sccache`
-RUN cargo install sccache --locked --version "${SCCACHE_TAG}"
 
 # Install QDK framework for QNAP packages (QPKG)
 RUN set -eux; \

--- a/builders/build-windows-rust/Dockerfile
+++ b/builders/build-windows-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77.2
+FROM rust:1.85.0
 
 ARG REVISION
 
@@ -6,9 +6,6 @@ LABEL org.opencontainers.image.source=https://github.com/NordSecurity/rust_build
 LABEL org.opencontainers.image.description="Windows Rust builder image"
 LABEL org.opencontainers.image.licenses=GPL-3.0
 LABEL org.opencontainers.image.revision=$REVISION
-
-# Download crates.io index - entire index won't have to be downloaded for each job
-RUN cargo search --limit 1
 
 ENV GO_VERSION=1.21.6 \
     GOROOT=/usr/local/go \
@@ -31,9 +28,6 @@ RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz; \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz; \
     rm go${GO_VERSION}.linux-amd64.tar.gz; \
     mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH";
-
-# Install `sccache`
-RUN cargo install sccache --locked --version 0.4.2 && rm -rf /usr/local/cargo/registry
 
 # Skip llt-secrets check when building in builder images
 ENV BYPASS_LLT_SECRETS=1

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -100,9 +100,9 @@ GLOBAL_CONFIG: Dict[str, Any] = {
         "archs": {
             "x86_64": {
                 "rust_target": "x86_64-apple-darwin",
-                "deployment_assert": ("LC_VERSION_MIN_MACOSX", "version", "10.7"),
+                "deployment_assert": ("LC_VERSION_MIN_MACOSX", "version", "10.12"),
                 "env": {
-                    "MACOSX_DEPLOYMENT_TARGET": (["10.7"], "set"),
+                    "MACOSX_DEPLOYMENT_TARGET": (["10.12"], "set"),
                 },
             },
             "aarch64": {

--- a/rust_sample/ci/build_sample.py
+++ b/rust_sample/ci/build_sample.py
@@ -13,7 +13,7 @@ import rust_build_utils.android_build_utils as abu
 
 
 PROJECT_CONFIG = rutils.Project(
-    rust_version="1.77.2",
+    rust_version="1.85.0",
     root_dir=PROJECT_ROOT,
     working_dir=None,
 )


### PR DESCRIPTION
Due to LLT-6056: protobuf security vulnerability, we need to bump the rust tooling version to update the dependency. We would like update it to the latest stable release `v1.85.0`.

The rust version increase also necessitates the following changes:
- `sccache` removed due to build errors and reported incorrect outputs in `libtelio`.
- increased minimum macOS version from `v10.7` to `v10.12` due to [rustc compatibility](https://blog.rust-lang.org/2023/09/25/Increasing-Apple-Version-Requirements.html)
- removed `cargo search --limit` as it's not working as intended to populate the cache.