### PR TITLE
LLT-6098: Use musl target for arm64 qnap

### DIFF
--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -60,6 +60,7 @@ RUN rustup target add \
         i686-unknown-linux-gnu \
         armv7-unknown-linux-gnueabihf \
         aarch64-unknown-linux-gnu \
+        aarch64-unknown-linux-musl \
         arm-unknown-linux-gnueabi
 
 RUN rustup component add clippy rustfmt

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -78,7 +78,7 @@ GLOBAL_CONFIG: Dict[str, Any] = {
             },
             "aarch64": {
                 "strip_path": "/usr/aarch64-linux-gnu/bin/objcopy",
-                "rust_target": "aarch64-unknown-linux-gnu",
+                "rust_target": "aarch64-unknown-linux-musl",
             },
         },
         "post_build": ["rust_build_utils.linux_build_utils.strip"],


### PR DESCRIPTION
- Add aarch64-unknown-linux-musl support