### PR TITLE
Add protoc compiler to images used for building

### DIFF
--- a/builders/build-android-rust/Dockerfile
+++ b/builders/build-android-rust/Dockerfile
@@ -49,5 +49,23 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         python3-requests && \
     rm -rf /var/lib/apt/lists/*
 
+RUN ARCH=$(uname -m) && \
+    case $ARCH in \
+        x86_64) \
+            PROTOC_ARCH="x86_64" && \
+            CHECKSUM="96553041f1a91ea0efee963cb16f462f5985b4d65365f3907414c360044d8065" ;; \
+        aarch64|arm64) \
+            PROTOC_ARCH="aarch_64" && \
+            CHECKSUM="6c554de11cea04c56ebf8e45b54434019b1cd85223d4bbd25c282425e306ecc2" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-${PROTOC_ARCH}.zip" && \
+    echo "${CHECKSUM}  protoc-31.1-linux-${PROTOC_ARCH}.zip" | sha256sum -c - && \
+    mkdir -p /root/.local && \
+    unzip "protoc-31.1-linux-${PROTOC_ARCH}.zip" -d /root/.local && \
+    rm "protoc-31.1-linux-${PROTOC_ARCH}.zip"
+
+ENV PATH="$PATH:/root/.local/bin"
+
 # Skip llt-secrets check when building in builder images
 ENV BYPASS_LLT_SECRETS=1

--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -54,6 +54,24 @@ RUN set -eux; \
         /usr/share/doc/ \
         /usr/share/man/
 
+RUN ARCH=$(uname -m) && \
+    case $ARCH in \
+        x86_64) \
+            PROTOC_ARCH="x86_64" && \
+            CHECKSUM="96553041f1a91ea0efee963cb16f462f5985b4d65365f3907414c360044d8065" ;; \
+        aarch64|arm64) \
+            PROTOC_ARCH="aarch_64" && \
+            CHECKSUM="6c554de11cea04c56ebf8e45b54434019b1cd85223d4bbd25c282425e306ecc2" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-${PROTOC_ARCH}.zip" && \
+    echo "${CHECKSUM}  protoc-31.1-linux-${PROTOC_ARCH}.zip" | sha256sum -c - && \
+    mkdir -p /root/.local && \
+    unzip "protoc-31.1-linux-${PROTOC_ARCH}.zip" -d /root/.local && \
+    rm "protoc-31.1-linux-${PROTOC_ARCH}.zip"
+
+ENV PATH="$PATH:/root/.local/bin"
+
 RUN rustup target add \
         x86_64-unknown-linux-gnu \
         x86_64-unknown-linux-musl \

--- a/builders/build-windows-rust/Dockerfile
+++ b/builders/build-windows-rust/Dockerfile
@@ -24,6 +24,24 @@ RUN set -eux; \
     rustup target add x86_64-pc-windows-gnu && \
     rm -rf /var/lib/apt/lists/*
 
+RUN ARCH=$(uname -m) && \
+    case $ARCH in \
+        x86_64) \
+            PROTOC_ARCH="x86_64" && \
+            CHECKSUM="96553041f1a91ea0efee963cb16f462f5985b4d65365f3907414c360044d8065" ;; \
+        aarch64|arm64) \
+            PROTOC_ARCH="aarch_64" && \
+            CHECKSUM="6c554de11cea04c56ebf8e45b54434019b1cd85223d4bbd25c282425e306ecc2" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-${PROTOC_ARCH}.zip" && \
+    echo "${CHECKSUM}  protoc-31.1-linux-${PROTOC_ARCH}.zip" | sha256sum -c - && \
+    mkdir -p /root/.local && \
+    unzip "protoc-31.1-linux-${PROTOC_ARCH}.zip" -d /root/.local && \
+    rm "protoc-31.1-linux-${PROTOC_ARCH}.zip"
+
+ENV PATH="$PATH:/root/.local/bin"
+
 RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz; \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz; \
     rm go${GO_VERSION}.linux-amd64.tar.gz; \

--- a/builders/package-aar-jdk-17/Dockerfile
+++ b/builders/package-aar-jdk-17/Dockerfile
@@ -28,6 +28,25 @@ RUN apt-get update && apt-get install -y \
         unzip \
         wget \
     && rm -rf /var/lib/apt/lists/*
+    
+RUN ARCH=$(uname -m) && \
+    case $ARCH in \
+        x86_64) \
+            PROTOC_ARCH="x86_64" && \
+            CHECKSUM="96553041f1a91ea0efee963cb16f462f5985b4d65365f3907414c360044d8065" ;; \
+        aarch64|arm64) \
+            PROTOC_ARCH="aarch_64" && \
+            CHECKSUM="6c554de11cea04c56ebf8e45b54434019b1cd85223d4bbd25c282425e306ecc2" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-${PROTOC_ARCH}.zip" && \
+    echo "${CHECKSUM}  protoc-31.1-linux-${PROTOC_ARCH}.zip" | sha256sum -c - && \
+    mkdir -p /root/.local && \
+    unzip "protoc-31.1-linux-${PROTOC_ARCH}.zip" -d /root/.local && \
+    rm "protoc-31.1-linux-${PROTOC_ARCH}.zip"
+
+ENV PATH="$PATH:/root/.local/bin"
+
 ENV ANDROID_SDK_CHECKSUM 8919e8752979db73d8321e9babe2caedcc393750817c1a5f56c128ec442fb540
 RUN wget --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_TOOLS}_latest.zip && \
     echo "${ANDROID_SDK_CHECKSUM} android-sdk.zip" | sha256sum --check && \

--- a/builders/package-aar/Dockerfile
+++ b/builders/package-aar/Dockerfile
@@ -22,6 +22,25 @@ RUN apt-get update && apt-get install -y \
     python3-requests \
     wget \
     && rm -rf /var/lib/apt/lists/*
+    
+RUN ARCH=$(uname -m) && \
+    case $ARCH in \
+        x86_64) \
+            PROTOC_ARCH="x86_64" && \
+            CHECKSUM="96553041f1a91ea0efee963cb16f462f5985b4d65365f3907414c360044d8065" ;; \
+        aarch64|arm64) \
+            PROTOC_ARCH="aarch_64" && \
+            CHECKSUM="6c554de11cea04c56ebf8e45b54434019b1cd85223d4bbd25c282425e306ecc2" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-${PROTOC_ARCH}.zip" && \
+    echo "${CHECKSUM}  protoc-31.1-linux-${PROTOC_ARCH}.zip" | sha256sum -c - && \
+    mkdir -p /root/.local && \
+    unzip "protoc-31.1-linux-${PROTOC_ARCH}.zip" -d /root/.local && \
+    rm "protoc-31.1-linux-${PROTOC_ARCH}.zip"
+
+ENV PATH="$PATH:/root/.local/bin"
+
 ENV ANDROID_SKD_CHECKSUM 92ffee5a1d98d856634e8b71132e8a95d96c83a63fde1099be3d86df3106def9
 RUN wget --output-document=android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_TOOLS}.zip && \
     echo "${ANDROID_SKD_CHECKSUM} android-sdk.zip" | sha256sum --check && \


### PR DESCRIPTION
This is required by the `tonic` crate which will be used to handle grpc for RFC-0091.