### PR TITLE
Revert "Openwrt support"

### DIFF
--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -29,7 +29,6 @@ RUN set -eux; \
         /usr/share/doc/ \
         /usr/share/man/
 
-        
 RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     apt-get update; \
@@ -48,13 +47,8 @@ RUN set -eux; \
         musl-tools \
         pip \
         python3-requests \
-        pkg-config \
-        # OpenWRT dependencies below
-        zstd build-essential clang flex bison g++ gawk \
-        gettext git libncurses5-dev \
-        python3-setuptools rsync swig unzip zlib1g-dev file wget \
-    ; \
-    rm -rf /var/lib/apt/lists/* \
+        pkg-config; \
+        rm -rf /var/lib/apt/lists/* \
         /var/cache/apt/* \
         /var/log/* \
         /usr/share/doc/ \
@@ -99,17 +93,6 @@ RUN set -eux; \
         /var/cache/apt/* /var/log/* \
         /usr/share/doc/ \
         /usr/share/man/
-
-
-# Download and extract OpenWRT SDK
-RUN set -eux; \
-    SDK_FILENAME="openwrt-sdk-24.10.1-x86-64_gcc-13.3.0_musl.Linux-x86_64.tar.zst"; \
-    SDK_URL="https://downloads.openwrt.org/releases/24.10.1/targets/x86/64/$SDK_FILENAME"; \
-    mkdir -p /usr/local/openwrt_sdk_x86_64; \
-    curl -LO "$SDK_URL"; \
-    zstd -dc "$SDK_FILENAME" | tar --strip-components=1 -xf - -C /usr/local/openwrt_sdk_x86_64; \
-    rm "$SDK_FILENAME"
-
 
 # Skip llt-secrets check when building in builder images
 ENV BYPASS_LLT_SECRETS=1

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -81,12 +81,6 @@ GLOBAL_CONFIG: Dict[str, Any] = {
         },
         "post_build": ["rust_build_utils.linux_build_utils.strip"],
     },
-    "openwrt": {
-        "archs": {
-            "x86_64": {},
-        },
-        "post_build": [],
-    },
     "qnap": {
         "archs": {
             "x86_64": {


### PR DESCRIPTION
Reverts NordSecurity/rust_build_utils#48

In hindsight - it is not correct to augment linux builder image with all the possible targets since it's wasteful, it makes more sense to have a separate image(s) for OpenWRT targets.

For OpenWRT there are already images on docker hub for each target platform. For this I am using those images in CI/CD and reverting OpenWRT addition in here.