### PR TITLE
LLT-6598: Bump uniffi-generators to v0.28.3-4

### DIFF
--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -7,10 +7,10 @@ LABEL org.opencontainers.image.description="Linux Rust builder image"
 LABEL org.opencontainers.image.licenses=GPL-3.0
 LABEL org.opencontainers.image.revision=$REVISION
 
-COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-3 /bin/uniffi-bindgen /bin
-COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-3 /bin/uniffi-bindgen-cs /bin
-COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-3 /bin/uniffi-bindgen-go /bin
-COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-3 /bin/uniffi-bindgen-cpp /bin
+COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-4 /bin/uniffi-bindgen /bin
+COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-4 /bin/uniffi-bindgen-cs /bin
+COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-4 /bin/uniffi-bindgen-go /bin
+COPY --from=ghcr.io/nordsecurity/uniffi-generators:v0.28.3-4 /bin/uniffi-bindgen-cpp /bin
 
 ENV QDK_TAG=v2.3.14
 

--- a/rust_sample/ci/build_sample.py
+++ b/rust_sample/ci/build_sample.py
@@ -215,7 +215,7 @@ def main() -> None:
         exec_build(args)
     elif args.command == "bindings":
         rutils.generate_uniffi_bindings(
-            PROJECT_CONFIG, "v0.28.3-3", ["python"], "src/sample.udl"
+            PROJECT_CONFIG, "v0.28.3-4", ["python"], "src/sample.udl"
         )
     elif args.command == "lipo":
         exec_lipo(args)


### PR DESCRIPTION
v0.28.3-3 has an issue for windows. v0.28.3-4 fixes that issue.