### PR TITLE
Add missing pieces for aws-lc to compile on windows builder image

### DIFF
--- a/builders/build-windows-rust/Dockerfile
+++ b/builders/build-windows-rust/Dockerfile
@@ -43,6 +43,7 @@ RUN ARCH=$(uname -m) && \
     rm "protoc-31.1-linux-${PROTOC_ARCH}.zip"
 
 ENV PATH="$PATH:/root/.local/bin"
+ENV AWS_LC_SYS_INCLUDES_x86_64_pc_windows_gnu="/usr/lib/gcc/x86_64-w64-mingw32/14-win32/include"
 
 RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz; \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz; \


### PR DESCRIPTION
This PR fixes 2 issues:
- missing libclang
- aws-lc was unable to find some of the inclueds

This was tested on a temporary PR in libtelio: https://github.com/NordSecurity/libtelio/pull/1442