### PR TITLE
[LLT-7142] Add armv7hf to OpenWrt

### DIFF
--- a/builders/package-openwrt/package.sh
+++ b/builders/package-openwrt/package.sh
@@ -108,6 +108,7 @@ if [ -z "$pkg_path" ]; then
 fi
 
 if [ -n "$OUTPUT_DIR" ]; then
+    mkdir -p "$OUTPUT_DIR"
     cp "$pkg_path" "$OUTPUT_DIR/"
 fi
 

--- a/builders/package-openwrt/package.sh
+++ b/builders/package-openwrt/package.sh
@@ -44,6 +44,7 @@ detect_binary_arch_from_bin() {
             esac
             ;;
         "AArch64") echo "aarch64" ;;
+        "ARM") echo "arm" ;;
         *) echo "ERROR: unsupported ELF: $machine" >&2; exit 1 ;;
     esac
 }

--- a/rust_build_utils/rust_utils_config.py
+++ b/rust_build_utils/rust_utils_config.py
@@ -62,6 +62,10 @@ GLOBAL_CONFIG: Dict[str, Any] = {
                 "strip_path": "/usr/aarch64-linux-gnu/bin/objcopy",
                 "rust_target": "aarch64-unknown-linux-musl",
             },
+            "armv7hf": {
+                "strip_path": "/opt/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-objcopy",
+                "rust_target": "armv7-unknown-linux-musleabihf",
+            },
         },
         "post_build": ["rust_build_utils.linux_build_utils.strip"],
     },


### PR DESCRIPTION
- Adds armv7hf to GLOBAL_CONFIG in `rust_build_utils/rust_utils_config.py`
- Adds ARM mapping to `builders/package-openwrt/package.sh `