### PR TITLE
[LLT-7142] Add build openwrt rust image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ on:
         options:
         - build-android-rust
         - build-linux-rust
+        - build-openwrt-rust
         - build-windows-rust
         - package-aar-jdk-17
         - test-nudler-nordvpn
@@ -60,7 +61,7 @@ jobs:
         file: builders/${{ inputs.name }}/Dockerfile
         builder: ${{ steps.buildx.outputs.name }}
         platforms: |-
-          ${{ (github.event.inputs.name == 'build-linux-rust' || github.event.inputs.name == 'build-windows-rust') && 'linux/amd64,linux/arm64' ||
+          ${{ (github.event.inputs.name == 'build-linux-rust' || github.event.inputs.name == 'build-windows-rust' || github.event.inputs.name == 'build-openwrt-rust') && 'linux/amd64,linux/arm64' ||
               'linux/amd64' }}
         push: true
         tags: ${{ env.REGISTRY }}/nordsecurity/${{ inputs.name }}${{ inputs.rust_version }}:${{ inputs.version }}
@@ -74,9 +75,9 @@ jobs:
         name:
           - build-android-rust
           - build-linux-rust
+          - build-openwrt-rust
           - build-windows-rust
           - package-aar-jdk-17
-
           - test-nudler-nordvpn
     runs-on: ubuntu-22.04
     permissions:
@@ -107,7 +108,7 @@ jobs:
         file: builders/${{ matrix.name }}/Dockerfile
         builder: ${{ steps.buildx.outputs.name }}
         platforms: |-
-          ${{ (matrix.name == 'build-linux-rust' || matrix.name == 'build-windows-rust') && 'linux/amd64,linux/arm64' ||
+          ${{ (matrix.name == 'build-linux-rust' || matrix.name == 'build-windows-rust' || matrix.name == 'build-openwrt-rust') && 'linux/amd64,linux/arm64' ||
               'linux/amd64' }}
         push: true
         tags: ${{ env.REGISTRY }}/nordsecurity/${{ matrix.name }}:debug-${{ github.sha }}

--- a/builders/build-linux-rust/Dockerfile
+++ b/builders/build-linux-rust/Dockerfile
@@ -45,8 +45,6 @@ RUN set -eux; \
         gcc-i686-linux-gnu \
         libclang-dev \
         libssl-dev \
-        musl-dev \
-        musl-tools \
         pip \
         python3-requests \
         pkg-config; \
@@ -76,7 +74,6 @@ ENV PATH="$PATH:/root/.local/bin"
 
 RUN rustup target add \
         x86_64-unknown-linux-gnu \
-        x86_64-unknown-linux-musl \
         i686-unknown-linux-gnu \
         armv7-unknown-linux-gnueabihf \
         aarch64-unknown-linux-gnu \
@@ -88,23 +85,6 @@ ENV AWS_LC_SYS_INCLUDES_aarch64_unknown_linux_gnu="/usr/aarch64-linux-gnu/includ
 ENV AWS_LC_SYS_INCLUDES_i686_unknown_linux_gnu="/usr/i686-linux-gnu/include/"
 ENV AWS_LC_SYS_INCLUDES_armv7_unknown_linux_gnueabihf="/usr/arm-linux-gnueabihf/include"
 ENV AWS_LC_SYS_INCLUDES_arm_unknown_linux_gnueabi="/usr/arm-linux-gnueabi/include"
-
-# musl.cc node (2025-05-27):
-#   "GitHub Actions has been blocked wholesale due to abuse similar to this."
-# Therefore, we fetch musl for mipsel from our own mirror
-RUN curl -LO https://github.com/NordSecurity/rust_build_utils/releases/download/mirror_mipsel-linux-muslsf-cross.tgz/mipsel-linux-muslsf-cross.tgz \
-    && tar -xzf mipsel-linux-muslsf-cross.tgz -C /opt \
-    && rm mipsel-linux-muslsf-cross.tgz
-
-RUN echo "[target.mipsel-unknown-linux-musl]\n" >> ${CARGO_HOME}/config.toml
-RUN echo "linker = \"/opt/mipsel-linux-muslsf-cross/bin/mipsel-linux-muslsf-gcc\"" >> ${CARGO_HOME}/config.toml
-
-RUN curl -LO https://github.com/NordSecurity/rust_build_utils/releases/download/mirror_mips-linux-muslsf-cross.tgz/mips-linux-muslsf-cross.tgz \
-    && tar -xzf mips-linux-muslsf-cross.tgz -C /opt \
-    && rm mips-linux-muslsf-cross.tgz
-
-RUN echo "[target.mips-unknown-linux-musl]\n" >> ${CARGO_HOME}/config.toml
-RUN echo "linker = \"/opt/mips-linux-muslsf-cross/bin/mips-linux-muslsf-gcc\"" >> ${CARGO_HOME}/config.toml
 
 # Skip llt-secrets check when building in builder images
 ENV BYPASS_LLT_SECRETS=1

--- a/builders/build-openwrt-rust/Dockerfile
+++ b/builders/build-openwrt-rust/Dockerfile
@@ -1,0 +1,76 @@
+FROM rust:1.89.0-bullseye
+
+ARG REVISION
+
+LABEL org.opencontainers.image.source=https://github.com/NordSecurity/rust_build_utils
+LABEL org.opencontainers.image.description="OpenWrt Rust builder image"
+LABEL org.opencontainers.image.revision=$REVISION
+
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update; \
+    apt-get install -y \
+        cmake \
+        # aarch64 musl builds use glibc gcc as linker
+        gcc-aarch64-linux-gnu \
+        libclang-dev \
+        libssl-dev \
+        musl-dev \
+        musl-tools \
+        python3-requests \
+        pkg-config; \
+    if apt-cache show pip > /dev/null 2>&1; then \
+        apt-get install -y pip; \
+    else \
+        apt-get install -y python3-pip; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*
+
+# protoc
+RUN ARCH=$(uname -m) && \
+    case $ARCH in \
+        x86_64) \
+            PROTOC_ARCH="x86_64" && \
+            CHECKSUM="96553041f1a91ea0efee963cb16f462f5985b4d65365f3907414c360044d8065" ;; \
+        aarch64|arm64) \
+            PROTOC_ARCH="aarch_64" && \
+            CHECKSUM="6c554de11cea04c56ebf8e45b54434019b1cd85223d4bbd25c282425e306ecc2" ;; \
+        *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
+    esac && \
+    curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-${PROTOC_ARCH}.zip" && \
+    echo "${CHECKSUM}  protoc-31.1-linux-${PROTOC_ARCH}.zip" | sha256sum -c - && \
+    mkdir -p /root/.local && \
+    unzip "protoc-31.1-linux-${PROTOC_ARCH}.zip" -d /root/.local && \
+    rm "protoc-31.1-linux-${PROTOC_ARCH}.zip"
+
+ENV PATH="$PATH:/root/.local/bin"
+
+# Musl cross-compilers (from our own mirrors — musl.cc blocks GitHub Actions)
+RUN curl -LO https://github.com/NordSecurity/rust_build_utils/releases/download/mirror_mipsel-linux-muslsf-cross.tgz/mipsel-linux-muslsf-cross.tgz \
+    && tar -xzf mipsel-linux-muslsf-cross.tgz -C /opt \
+    && rm mipsel-linux-muslsf-cross.tgz
+
+RUN curl -LO https://github.com/NordSecurity/rust_build_utils/releases/download/mirror_mips-linux-muslsf-cross.tgz/mips-linux-muslsf-cross.tgz \
+    && tar -xzf mips-linux-muslsf-cross.tgz -C /opt \
+    && rm mips-linux-muslsf-cross.tgz
+
+RUN curl -LO https://github.com/NordSecurity/rust_build_utils/releases/download/mirror_arm-linux-musleabihf-cross.tgz/arm-linux-musleabihf-cross.tgz \
+    && tar -xzf arm-linux-musleabihf-cross.tgz -C /opt \
+    && rm arm-linux-musleabihf-cross.tgz
+
+# Rust musl targets
+RUN rustup target add \
+        x86_64-unknown-linux-musl \
+        aarch64-unknown-linux-musl \
+        armv7-unknown-linux-musleabihf
+
+RUN rustup component add clippy rustfmt
+
+# Cargo linker config for cross-compilation
+COPY builders/build-openwrt-rust/cargo-config.toml ${CARGO_HOME}/config.toml
+
+# AWS LC includes for cross-compilation
+ENV AWS_LC_SYS_INCLUDES_aarch64_unknown_linux_musl="/usr/aarch64-linux-gnu/include"
+ENV AWS_LC_SYS_INCLUDES_armv7_unknown_linux_musleabihf="/opt/arm-linux-musleabihf-cross/arm-linux-musleabihf/include"
+
+ENV BYPASS_LLT_SECRETS=1

--- a/builders/build-openwrt-rust/cargo-config.toml
+++ b/builders/build-openwrt-rust/cargo-config.toml
@@ -1,0 +1,11 @@
+[target.mipsel-unknown-linux-musl]
+linker = "/opt/mipsel-linux-muslsf-cross/bin/mipsel-linux-muslsf-gcc"
+
+[target.mips-unknown-linux-musl]
+linker = "/opt/mips-linux-muslsf-cross/bin/mips-linux-muslsf-gcc"
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "/opt/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc"
+
+[target.aarch64-unknown-linux-musl]
+linker = "aarch64-linux-gnu-gcc"


### PR DESCRIPTION
Split OpenWrt builds into a separate build-openwrt-rust Docker image to support arm64 CI runners. The new image includes musl cross-compilers for mipsel, mips, aarch64, and armv7 targets.

  - Add `builders/build-openwrt-rust/Dockerfile`
  - Remove openwrt specific tooling from `build-linux-rust/Dockerfile` (musl packages, mipsel/mips cross-compilers and cargo linker config)
  - Enable multi-platform (linux/amd64,linux/arm64) builds for build-openwrt-rust in the CI workflow